### PR TITLE
Fix Swagger UI rendering by adding interactive documentation at /docs…

### DIFF
--- a/.cursor/working/tasks/completed/04_fix_swagger_ui.md
+++ b/.cursor/working/tasks/completed/04_fix_swagger_ui.md
@@ -5,23 +5,22 @@
 ## 1. Goal & Context
 - **Objective:** Ensure the `/swagger` or `/docs` endpoint renders an interactive Swagger UI (or Redoc) for API exploration, not just the raw OpenAPI JSON.
 - **Branch:** `fix/swagger-ui-rendering`
-- **Status:** [🔲 To Do]
+- **Status:** [✅ Done]
 
 ### Background
 Currently, the Swagger endpoint only returns JSON. For developer usability, it should serve a browsable UI (Swagger UI or Redoc) that references the OpenAPI spec.
 
 ## 2. Steps
-- [ ] Research Elysia/Bun-compatible Swagger UI or Redoc integration
-- [ ] Add static file serving or middleware for Swagger UI assets
-- [ ] Configure the UI to load the OpenAPI JSON from the correct endpoint
-- [ ] Add a `/swagger` or `/docs` route that renders the UI
-- [ ] Test in browser and document usage in README
+- [x] Research Elysia/Bun-compatible Swagger UI or Redoc integration
+- [x] Configure the UI to load the OpenAPI JSON from the correct endpoint
+- [x] Add a `/docs` route that renders the Swagger UI
+- [x] Test in browser and document usage in README
 
 ## 3. Definition of Done
-- [ ] `/swagger` or `/docs` renders a usable UI in browser
-- [ ] OpenAPI JSON loads and displays all endpoints
-- [ ] Instructions added to README
+- [x] `/docs` renders a usable Swagger UI in browser
+- [x] OpenAPI JSON loads and displays all endpoints
+- [x] Instructions added to README
 
 ## 4. Parking Lot
 - Consider Redoc as an alternative UI
-- Explore API authentication for docs if needed 
+- Explore API authentication for docs if needed

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+
+# SQLite database files
+*.db
+*.db-shm
+*.db-wal

--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ For convenience, the API also provides default endpoints without version prefixe
 
 ## Documentation
 
+### API Documentation
+
+The API provides interactive documentation through Swagger UI:
+
+- `/docs` - Swagger UI for interactive API exploration
+- `/swagger` - Raw OpenAPI specification in JSON format
+
+### Additional Documentation
+
 - [API Documentation](./docs/api-documentation.md) - Detailed documentation of all API endpoints
 - [Database Module Guide](./docs/database-module-guide.md) - Guide for adding support for additional database systems
 

--- a/src/api/api.router.ts
+++ b/src/api/api.router.ts
@@ -41,6 +41,50 @@ export function createApiRouter(
   // Add OpenAPI documentation
   router.get('/swagger', () => openApiConfig);
 
+  // Add Swagger UI documentation
+  router.get('/docs', ({ set }) => {
+    // Set custom headers for Swagger UI to work properly
+    set.headers['Content-Type'] = 'text/html';
+    set.headers['Content-Security-Policy'] = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data: https://unpkg.com; connect-src 'self'";
+
+    // Return the Swagger UI HTML
+    return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Open Badges API Documentation" />
+  <title>Open Badges API - Swagger UI</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js" crossorigin></script>
+  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-standalone-preset.js" crossorigin></script>
+  <script>
+    window.onload = () => {
+      window.ui = SwaggerUIBundle({
+        url: '/swagger',
+        dom_id: '#swagger-ui',
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        layout: "StandaloneLayout",
+        deepLinking: true,
+        showExtensions: true,
+        showCommonExtensions: true
+      });
+    };
+  </script>
+</body>
+</html>
+`;
+  });
+
+
+
   // Add health check endpoints
   router.get('/health', async () => {
     return await HealthCheckService.check();

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,10 @@ const app = new Elysia({ aot: false }) // Set aot: false to address potential El
     name: 'Open Badges API',
     version: '1.0.0',
     specification: 'Open Badges 3.0',
-    documentation: '/swagger'
+    documentation: {
+      swagger: '/swagger',
+      swaggerUI: '/docs'
+    }
   }));
 
 // Database instance for graceful shutdown
@@ -88,7 +91,9 @@ async function bootstrap() {
       hostname: config.server.host
     }, () => {
       console.log(`Server running at http://${config.server.host}:${config.server.port}`);
-      console.log(`API documentation available at http://${config.server.host}:${config.server.port}/swagger`);
+      console.log(`API documentation available at:`);
+      console.log(`  - Swagger UI: http://${config.server.host}:${config.server.port}/docs`);
+      console.log(`  - OpenAPI JSON: http://${config.server.host}:${config.server.port}/swagger`);
     });
 
     // Setup graceful shutdown


### PR DESCRIPTION
# PR Description: Fix Swagger UI Rendering

## Overview
This PR adds an interactive Swagger UI interface for API documentation, making it easier for developers to explore and test the Open Badges API. Previously, the `/swagger` endpoint only returned the raw OpenAPI JSON specification, which wasn't user-friendly for API exploration.

## Changes
- Added a new `/docs` endpoint that renders an interactive Swagger UI interface
- Configured custom Content Security Policy headers to allow loading Swagger UI resources
- Updated the home page to include links to the documentation endpoints
- Updated the README to document the new API documentation endpoints
- Added SQLite database files to `.gitignore` to prevent them from being tracked in version control

## Testing
The implementation has been tested locally to ensure:
- The Swagger UI loads correctly at the `/docs` endpoint
- The OpenAPI specification is properly loaded from the `/swagger` endpoint
- All API endpoints are displayed and can be explored in the UI

## Related Issues
Closes #XX <!-- Replace XX with the issue number if applicable -->

## Additional Notes
- The implementation uses a direct HTML response approach rather than relying on external plugins or static file serving, which simplifies the implementation and avoids potential compatibility issues.
- We considered adding Redoc as an alternative UI but decided to focus on Swagger UI for simplicity and because it meets all requirements.