### PR TITLE
Unify SQLite Repository Implementation using Drizzle ORM

### DIFF
--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
@@ -28,14 +28,14 @@ export class SqlitePlatformUserMapper {
 
     // Return database record
     return {
-      id: convertUuid(data.id, 'sqlite', 'to') as string,
-      platformId: convertUuid(data.platformId, 'sqlite', 'to') as string,
-      externalUserId: data.externalUserId,
-      displayName: data.displayName || null,
-      email: data.email || null,
+      id: convertUuid(data.id as string, 'sqlite', 'to') as string,
+      platformId: convertUuid(data.platformId as string, 'sqlite', 'to') as string,
+      externalUserId: String(data.externalUserId),
+      displayName: data.displayName ? String(data.displayName) : null,
+      email: data.email ? String(data.email) : null,
       metadata: convertJson(data.metadata, 'sqlite', 'to') as string | null,
-      createdAt: convertTimestamp(data.createdAt, 'sqlite', 'to') as number,
-      updatedAt: convertTimestamp(data.updatedAt, 'sqlite', 'to') as number
+      createdAt: convertTimestamp(data.createdAt as Date, 'sqlite', 'to') as number,
+      updatedAt: convertTimestamp(data.updatedAt as Date, 'sqlite', 'to') as number
     };
   }
 
@@ -46,7 +46,8 @@ export class SqlitePlatformUserMapper {
    */
   toDomain(record: InferSelectModel<typeof platformUsers>): PlatformUser {
     // Parse metadata
-    const metadata = convertJson(record.metadata, 'sqlite', 'from') as Record<string, unknown> | undefined;
+    const parsedMetadata = convertJson(record.metadata, 'sqlite', 'from');
+    const metadata = typeof parsedMetadata === 'object' ? parsedMetadata as Record<string, unknown> : undefined;
 
     // Create and return domain entity
     return PlatformUser.create({

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
@@ -36,16 +36,19 @@ export class SqlitePlatformUserMapper {
     };
 
     // Add optional fields if they exist
+    // Use type assertion with Record<string, unknown> to add optional fields
+    const extendedRecord = record as Record<string, unknown>;
+
     if (data.displayName) {
-      (record as any).displayName = String(data.displayName);
+      extendedRecord.displayName = String(data.displayName);
     }
 
     if (data.email) {
-      (record as any).email = String(data.email);
+      extendedRecord.email = String(data.email);
     }
 
     if (data.metadata) {
-      (record as any).metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
+      extendedRecord.metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
     }
 
     return record;

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
@@ -1,0 +1,62 @@
+/**
+ * SQLite mapper for the PlatformUser domain entity
+ *
+ * This class implements the Data Mapper pattern for the PlatformUser entity,
+ * handling the conversion between domain entities and database records.
+ */
+
+import { PlatformUser } from '@domains/backpack/platform-user.entity';
+import { Shared } from 'openbadges-types';
+import { convertJson, convertTimestamp, convertUuid } from '@infrastructure/database/utils/type-conversion';
+import { InferSelectModel, InferInsertModel } from 'drizzle-orm';
+import { platformUsers } from '../schema';
+import { logger } from '@utils/logging/logger.service';
+
+/**
+ * SQLite mapper for the PlatformUser domain entity
+ */
+export class SqlitePlatformUserMapper {
+  /**
+   * Converts a domain entity to a database record
+   * @param entity The domain entity to convert
+   * @returns A database record suitable for insertion
+   */
+  toPersistence(entity: PlatformUser): InferInsertModel<typeof platformUsers> {
+    // Get entity data
+    const data = entity.toObject();
+
+    // Return database record
+    return {
+      id: convertUuid(data.id, 'sqlite', 'to') as string,
+      platformId: convertUuid(data.platformId, 'sqlite', 'to') as string,
+      externalUserId: data.externalUserId,
+      displayName: data.displayName || null,
+      email: data.email || null,
+      metadata: convertJson(data.metadata, 'sqlite', 'to') as string | null,
+      createdAt: convertTimestamp(data.createdAt, 'sqlite', 'to') as number,
+      updatedAt: convertTimestamp(data.updatedAt, 'sqlite', 'to') as number
+    };
+  }
+
+  /**
+   * Converts a database record to a domain entity
+   * @param record The database record to convert
+   * @returns A domain entity
+   */
+  toDomain(record: InferSelectModel<typeof platformUsers>): PlatformUser {
+    // Parse metadata
+    const metadata = convertJson(record.metadata, 'sqlite', 'from') as Record<string, unknown> | undefined;
+
+    // Create and return domain entity
+    return PlatformUser.create({
+      id: convertUuid(record.id, 'sqlite', 'from') as Shared.IRI,
+      platformId: convertUuid(record.platformId, 'sqlite', 'from') as Shared.IRI,
+      externalUserId: record.externalUserId,
+      displayName: record.displayName || undefined,
+      email: record.email || undefined,
+      metadata,
+      createdAt: convertTimestamp(record.createdAt, 'sqlite', 'from') as Date,
+      updatedAt: convertTimestamp(record.updatedAt, 'sqlite', 'from') as Date
+    });
+  }
+}

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
@@ -10,7 +10,8 @@ import { Shared } from 'openbadges-types';
 import { convertJson, convertTimestamp, convertUuid } from '@infrastructure/database/utils/type-conversion';
 import { InferSelectModel, InferInsertModel } from 'drizzle-orm';
 import { platformUsers } from '../schema';
-import { logger } from '@utils/logging/logger.service';
+// Import logger if needed for error handling
+// import { logger } from '@utils/logging/logger.service';
 
 /**
  * SQLite mapper for the PlatformUser domain entity

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
@@ -26,17 +26,29 @@ export class SqlitePlatformUserMapper {
     // Get entity data
     const data = entity.toObject();
 
-    // Create the record with all fields
-    return {
+    // Create the record with required fields
+    const record: InferInsertModel<typeof platformUsers> = {
       id: convertUuid(data.id as string, 'sqlite', 'to') as string,
       platformId: convertUuid(data.platformId as string, 'sqlite', 'to') as string,
       externalUserId: String(data.externalUserId),
-      displayName: data.displayName ? String(data.displayName) : null,
-      email: data.email ? String(data.email) : null,
-      metadata: data.metadata ? convertJson(data.metadata, 'sqlite', 'to') as string : null,
       createdAt: convertTimestamp(data.createdAt as Date, 'sqlite', 'to') as number,
       updatedAt: convertTimestamp(data.updatedAt as Date, 'sqlite', 'to') as number
     };
+
+    // Add optional fields if they exist
+    if (data.displayName) {
+      (record as any).displayName = String(data.displayName);
+    }
+
+    if (data.email) {
+      (record as any).email = String(data.email);
+    }
+
+    if (data.metadata) {
+      (record as any).metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
+    }
+
+    return record;
   }
 
   /**

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
@@ -26,17 +26,29 @@ export class SqlitePlatformUserMapper {
     // Get entity data
     const data = entity.toObject();
 
-    // Return database record
-    return {
+    // Create the record with required fields
+    const record: InferInsertModel<typeof platformUsers> = {
       id: convertUuid(data.id as string, 'sqlite', 'to') as string,
       platformId: convertUuid(data.platformId as string, 'sqlite', 'to') as string,
       externalUserId: String(data.externalUserId),
-      displayName: data.displayName ? String(data.displayName) : null,
-      email: data.email ? String(data.email) : null,
-      metadata: convertJson(data.metadata, 'sqlite', 'to') as string | null,
       createdAt: convertTimestamp(data.createdAt as Date, 'sqlite', 'to') as number,
       updatedAt: convertTimestamp(data.updatedAt as Date, 'sqlite', 'to') as number
     };
+
+    // Add optional fields if they exist
+    if (data.displayName) {
+      record.displayName = String(data.displayName);
+    }
+
+    if (data.email) {
+      record.email = String(data.email);
+    }
+
+    if (data.metadata) {
+      record.metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
+    }
+
+    return record;
   }
 
   /**

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
@@ -39,15 +39,15 @@ export class SqlitePlatformUserMapper {
     // Use type assertion with Record<string, unknown> to add optional fields
     const extendedRecord = record as Record<string, unknown>;
 
-    if (data.displayName) {
+    if (data.displayName !== undefined) {
       extendedRecord.displayName = String(data.displayName);
     }
 
-    if (data.email) {
+    if (data.email !== undefined) {
       extendedRecord.email = String(data.email);
     }
 
-    if (data.metadata) {
+    if (data.metadata !== undefined) {
       extendedRecord.metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
     }
 

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
@@ -26,29 +26,17 @@ export class SqlitePlatformUserMapper {
     // Get entity data
     const data = entity.toObject();
 
-    // Create the record with required fields
-    const record: InferInsertModel<typeof platformUsers> = {
+    // Create the record with all fields
+    return {
       id: convertUuid(data.id as string, 'sqlite', 'to') as string,
       platformId: convertUuid(data.platformId as string, 'sqlite', 'to') as string,
       externalUserId: String(data.externalUserId),
+      displayName: data.displayName ? String(data.displayName) : null,
+      email: data.email ? String(data.email) : null,
+      metadata: data.metadata ? convertJson(data.metadata, 'sqlite', 'to') as string : null,
       createdAt: convertTimestamp(data.createdAt as Date, 'sqlite', 'to') as number,
       updatedAt: convertTimestamp(data.updatedAt as Date, 'sqlite', 'to') as number
     };
-
-    // Add optional fields if they exist
-    if (data.displayName) {
-      record.displayName = String(data.displayName);
-    }
-
-    if (data.email) {
-      record.email = String(data.email);
-    }
-
-    if (data.metadata) {
-      record.metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
-    }
-
-    return record;
   }
 
   /**

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-platform-user.mapper.ts
@@ -76,4 +76,34 @@ export class SqlitePlatformUserMapper {
       updatedAt: convertTimestamp(record.updatedAt, 'sqlite', 'from') as Date
     });
   }
+
+  /**
+   * Creates an update object for the database from a persistence record
+   * @param record The persistence record to create an update object from
+   * @returns An object suitable for updating the database
+   */
+  toUpdateObject(record: InferInsertModel<typeof platformUsers>): Record<string, unknown> {
+    // Create the update object with required fields
+    const updateData: Record<string, unknown> = {
+      platformId: record.platformId,
+      externalUserId: record.externalUserId,
+      updatedAt: record.updatedAt
+    };
+
+    // Add optional fields with null handling
+    const extendedRecord = record as Record<string, unknown>;
+    if ('displayName' in extendedRecord) {
+      updateData.displayName = extendedRecord.displayName ?? null;
+    }
+
+    if ('email' in extendedRecord) {
+      updateData.email = extendedRecord.email ?? null;
+    }
+
+    if ('metadata' in extendedRecord) {
+      updateData.metadata = extendedRecord.metadata ?? null;
+    }
+
+    return updateData;
+  }
 }

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
@@ -27,21 +27,15 @@ export class SqliteUserAssertionMapper {
     // Get entity data
     const data = entity.toObject();
 
-    // Create the base record with required fields
-    const record: InferInsertModel<typeof userAssertions> = {
+    // Create the record with all fields
+    return {
       id: convertUuid(data.id as string, 'sqlite', 'to') as string,
       userId: convertUuid(data.userId as string, 'sqlite', 'to') as string,
       assertionId: convertUuid(data.assertionId as string, 'sqlite', 'to') as string,
       addedAt: convertTimestamp(data.addedAt as Date, 'sqlite', 'to') as number,
-      status: String(data.status)
+      status: String(data.status),
+      metadata: data.metadata ? convertJson(data.metadata, 'sqlite', 'to') as string : null
     };
-
-    // Add optional fields if they exist
-    if (data.metadata) {
-      record.metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
-    }
-
-    return record;
   }
 
   /**

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
@@ -27,15 +27,24 @@ export class SqliteUserAssertionMapper {
     // Get entity data
     const data = entity.toObject();
 
-    // Create the record with all fields
-    return {
+    // Create the record with required fields
+    const record: InferInsertModel<typeof userAssertions> = {
       id: convertUuid(data.id as string, 'sqlite', 'to') as string,
       userId: convertUuid(data.userId as string, 'sqlite', 'to') as string,
       assertionId: convertUuid(data.assertionId as string, 'sqlite', 'to') as string,
-      addedAt: convertTimestamp(data.addedAt as Date, 'sqlite', 'to') as number,
-      status: String(data.status),
-      metadata: data.metadata ? convertJson(data.metadata, 'sqlite', 'to') as string : null
+      addedAt: convertTimestamp(data.addedAt as Date, 'sqlite', 'to') as number
     };
+
+    // Add optional fields if they exist
+    if (data.status) {
+      (record as any).status = String(data.status);
+    }
+
+    if (data.metadata) {
+      (record as any).metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
+    }
+
+    return record;
   }
 
   /**

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
@@ -10,7 +10,8 @@ import { Shared } from 'openbadges-types';
 import { convertJson, convertTimestamp, convertUuid } from '@infrastructure/database/utils/type-conversion';
 import { InferSelectModel, InferInsertModel } from 'drizzle-orm';
 import { userAssertions } from '../schema';
-import { logger } from '@utils/logging/logger.service';
+// Import logger if needed for error handling
+// import { logger } from '@utils/logging/logger.service';
 import { UserAssertionStatus } from '@domains/backpack/backpack.types';
 
 /**

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
@@ -39,11 +39,11 @@ export class SqliteUserAssertionMapper {
     // Use type assertion with Record<string, unknown> to add optional fields
     const extendedRecord = record as Record<string, unknown>;
 
-    if (data.status) {
+    if (data.status !== undefined) {
       extendedRecord.status = String(data.status);
     }
 
-    if (data.metadata) {
+    if (data.metadata !== undefined) {
       extendedRecord.metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
     }
 

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
@@ -1,0 +1,59 @@
+/**
+ * SQLite mapper for the UserAssertion domain entity
+ *
+ * This class implements the Data Mapper pattern for the UserAssertion entity,
+ * handling the conversion between domain entities and database records.
+ */
+
+import { UserAssertion } from '@domains/backpack/user-assertion.entity';
+import { Shared } from 'openbadges-types';
+import { convertJson, convertTimestamp, convertUuid } from '@infrastructure/database/utils/type-conversion';
+import { InferSelectModel, InferInsertModel } from 'drizzle-orm';
+import { userAssertions } from '../schema';
+import { logger } from '@utils/logging/logger.service';
+import { UserAssertionStatus } from '@domains/backpack/backpack.types';
+
+/**
+ * SQLite mapper for the UserAssertion domain entity
+ */
+export class SqliteUserAssertionMapper {
+  /**
+   * Converts a domain entity to a database record
+   * @param entity The domain entity to convert
+   * @returns A database record suitable for insertion
+   */
+  toPersistence(entity: UserAssertion): InferInsertModel<typeof userAssertions> {
+    // Get entity data
+    const data = entity.toObject();
+
+    // Return database record
+    return {
+      id: convertUuid(data.id, 'sqlite', 'to') as string,
+      userId: convertUuid(data.userId, 'sqlite', 'to') as string,
+      assertionId: convertUuid(data.assertionId, 'sqlite', 'to') as string,
+      addedAt: convertTimestamp(data.addedAt, 'sqlite', 'to') as number,
+      status: data.status,
+      metadata: convertJson(data.metadata, 'sqlite', 'to') as string | null
+    };
+  }
+
+  /**
+   * Converts a database record to a domain entity
+   * @param record The database record to convert
+   * @returns A domain entity
+   */
+  toDomain(record: InferSelectModel<typeof userAssertions>): UserAssertion {
+    // Parse metadata
+    const metadata = convertJson(record.metadata, 'sqlite', 'from') as Record<string, unknown> | undefined;
+
+    // Create and return domain entity
+    return UserAssertion.create({
+      id: convertUuid(record.id, 'sqlite', 'from') as Shared.IRI,
+      userId: convertUuid(record.userId, 'sqlite', 'from') as Shared.IRI,
+      assertionId: convertUuid(record.assertionId, 'sqlite', 'from') as Shared.IRI,
+      addedAt: convertTimestamp(record.addedAt, 'sqlite', 'from') as Date,
+      status: record.status as UserAssertionStatus,
+      metadata
+    });
+  }
+}

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
@@ -36,12 +36,15 @@ export class SqliteUserAssertionMapper {
     };
 
     // Add optional fields if they exist
+    // Use type assertion with Record<string, unknown> to add optional fields
+    const extendedRecord = record as Record<string, unknown>;
+
     if (data.status) {
-      (record as any).status = String(data.status);
+      extendedRecord.status = String(data.status);
     }
 
     if (data.metadata) {
-      (record as any).metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
+      extendedRecord.metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
     }
 
     return record;

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
@@ -33,9 +33,13 @@ export class SqliteUserAssertionMapper {
       userId: convertUuid(data.userId as string, 'sqlite', 'to') as string,
       assertionId: convertUuid(data.assertionId as string, 'sqlite', 'to') as string,
       addedAt: convertTimestamp(data.addedAt as Date, 'sqlite', 'to') as number,
-      status: String(data.status),
-      metadata: convertJson(data.metadata, 'sqlite', 'to') as string | null
+      status: String(data.status)
     };
+
+    // Add optional fields if they exist
+    if (data.metadata) {
+      record.metadata = convertJson(data.metadata, 'sqlite', 'to') as string;
+    }
 
     return record;
   }

--- a/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
+++ b/src/infrastructure/database/modules/sqlite/mappers/sqlite-user-assertion.mapper.ts
@@ -27,15 +27,17 @@ export class SqliteUserAssertionMapper {
     // Get entity data
     const data = entity.toObject();
 
-    // Return database record
-    return {
-      id: convertUuid(data.id, 'sqlite', 'to') as string,
-      userId: convertUuid(data.userId, 'sqlite', 'to') as string,
-      assertionId: convertUuid(data.assertionId, 'sqlite', 'to') as string,
-      addedAt: convertTimestamp(data.addedAt, 'sqlite', 'to') as number,
-      status: data.status,
+    // Create the base record with required fields
+    const record: InferInsertModel<typeof userAssertions> = {
+      id: convertUuid(data.id as string, 'sqlite', 'to') as string,
+      userId: convertUuid(data.userId as string, 'sqlite', 'to') as string,
+      assertionId: convertUuid(data.assertionId as string, 'sqlite', 'to') as string,
+      addedAt: convertTimestamp(data.addedAt as Date, 'sqlite', 'to') as number,
+      status: String(data.status),
       metadata: convertJson(data.metadata, 'sqlite', 'to') as string | null
     };
+
+    return record;
   }
 
   /**
@@ -45,7 +47,8 @@ export class SqliteUserAssertionMapper {
    */
   toDomain(record: InferSelectModel<typeof userAssertions>): UserAssertion {
     // Parse metadata
-    const metadata = convertJson(record.metadata, 'sqlite', 'from') as Record<string, unknown> | undefined;
+    const parsedMetadata = convertJson(record.metadata, 'sqlite', 'from');
+    const metadata = typeof parsedMetadata === 'object' ? parsedMetadata as Record<string, unknown> : undefined;
 
     // Create and return domain entity
     return UserAssertion.create({

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
@@ -120,29 +120,9 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
         updatedAt: new Date()
       });
 
-      // Convert domain entity to database record
+      // Convert domain entity to database record and create update object
       const record = this.mapper.toPersistence(mergedUser);
-
-      // Prepare update data with required fields
-      const updateData: Record<string, unknown> = {
-        platformId: record.platformId,
-        externalUserId: record.externalUserId,
-        updatedAt: record.updatedAt
-      };
-
-      // Add optional fields with null handling
-      const extendedRecord = record as Record<string, unknown>;
-      if ('displayName' in extendedRecord) {
-        updateData.displayName = extendedRecord.displayName ?? null;
-      }
-
-      if ('email' in extendedRecord) {
-        updateData.email = extendedRecord.email ?? null;
-      }
-
-      if ('metadata' in extendedRecord) {
-        updateData.metadata = extendedRecord.metadata ?? null;
-      }
+      const updateData = this.mapper.toUpdateObject(record);
 
       // Update in database using Drizzle ORM
       await this.db

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
@@ -2,75 +2,45 @@
  * SQLite implementation of the PlatformUser repository
  *
  * This class implements the PlatformUserRepository interface using SQLite
+ * and the Data Mapper pattern with Drizzle ORM.
  */
 
+import { eq, and, InferInsertModel } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
 import { PlatformUser } from '@domains/backpack/platform-user.entity';
 import type { PlatformUserRepository } from '@domains/backpack/platform-user.repository';
 import { Shared } from 'openbadges-types';
 import { logger } from '@utils/logging/logger.service';
-import { InferSelectModel } from 'drizzle-orm';
 import { platformUsers } from '../schema';
-import {
-  convertJson,
-  convertTimestamp,
-  convertUuid,
-} from '@infrastructure/database/utils/type-conversion';
-
-type SqlitePlatformUserRecord = InferSelectModel<typeof platformUsers>;
+import { SqlitePlatformUserMapper } from '../mappers/sqlite-platform-user.mapper';
+import { createId } from '@paralleldrive/cuid2';
 
 export class SqlitePlatformUserRepository implements PlatformUserRepository {
-  private db: Database;
+  private db: ReturnType<typeof drizzle>;
+  private mapper: SqlitePlatformUserMapper;
 
-  constructor(db: Database) {
-    this.db = db;
-
-    // Create the platform_users table if it doesn't exist
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS platform_users (
-        id TEXT PRIMARY KEY,
-        platformId TEXT NOT NULL,
-        externalUserId TEXT NOT NULL,
-        displayName TEXT,
-        email TEXT,
-        metadata TEXT,
-        createdAt TEXT NOT NULL,
-        updatedAt TEXT NOT NULL,
-        FOREIGN KEY (platformId) REFERENCES platforms(id) ON DELETE CASCADE,
-        UNIQUE (platformId, externalUserId)
-      )
-    `);
-
-    // Create indexes
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_platform_users_platform_external ON platform_users(platformId, externalUserId)`);
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_platform_users_email ON platform_users(email)`);
+  constructor(client: Database) {
+    this.db = drizzle(client);
+    this.mapper = new SqlitePlatformUserMapper();
   }
 
   async create(user: Omit<PlatformUser, 'id'>): Promise<PlatformUser> {
     try {
-      // Create a new platform user entity
-      const newUser = PlatformUser.create(user as PlatformUser);
-      const obj = newUser.toObject();
+      // Generate ID and create full entity
+      const id = createId() as Shared.IRI;
+      const newUser = PlatformUser.create({ ...user, id } as PlatformUser);
 
-      // Convert metadata to JSON string if it exists
-      const metadata = obj.metadata ? JSON.stringify(obj.metadata) : null;
+      // Convert domain entity to database record
+      const record = this.mapper.toPersistence(newUser);
 
       // Insert into database
-      this.db.prepare(`
-        INSERT INTO platform_users (
-          id, platformId, externalUserId, displayName, email, metadata, createdAt, updatedAt
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(
-        String(obj.id),
-        String(obj.platformId),
-        String(obj.externalUserId),
-        obj.displayName ? String(obj.displayName) : null,
-        obj.email ? String(obj.email) : null,
-        metadata,
-        (obj.createdAt instanceof Date) ? obj.createdAt.toISOString() : String(obj.createdAt),
-        (obj.updatedAt instanceof Date) ? obj.updatedAt.toISOString() : String(obj.updatedAt)
-      );
+      const result = await this.db
+        .insert(platformUsers)
+        .values(record)
+        .returning();
 
+      // Return the domain entity
       return newUser;
     } catch (error) {
       logger.error('Error creating platform user in SQLite repository', {
@@ -83,18 +53,19 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
 
   async findById(id: Shared.IRI): Promise<PlatformUser | null> {
     try {
-      // Query database
-      const row = this.db
-        .prepare(`SELECT * FROM platform_users WHERE id = ?`)
-        .get(id) as SqlitePlatformUserRecord | undefined;
+      // Query database using Drizzle ORM
+      const result = await this.db
+        .select()
+        .from(platformUsers)
+        .where(eq(platformUsers.id, id as string));
 
       // Return null if not found
-      if (!row) {
+      if (!result.length) {
         return null;
       }
 
-      // Convert row to domain entity
-      return this.rowToDomain(row);
+      // Convert database record to domain entity
+      return this.mapper.toDomain(result[0]);
     } catch (error) {
       logger.error('Error finding platform user by ID in SQLite repository', {
         error: error instanceof Error ? error.message : String(error),
@@ -106,19 +77,24 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
 
   async findByPlatformAndExternalId(platformId: Shared.IRI, externalUserId: string): Promise<PlatformUser | null> {
     try {
-      // Query database
-      const row = this.db.prepare(`
-        SELECT * FROM platform_users
-        WHERE platformId = ? AND externalUserId = ?
-      `).get(platformId, externalUserId) as SqlitePlatformUserRecord | undefined;
+      // Query database using Drizzle ORM
+      const result = await this.db
+        .select()
+        .from(platformUsers)
+        .where(
+          and(
+            eq(platformUsers.platformId, platformId as string),
+            eq(platformUsers.externalUserId, externalUserId)
+          )
+        );
 
       // Return null if not found
-      if (!row) {
+      if (!result.length) {
         return null;
       }
 
-      // Convert row to domain entity
-      return this.rowToDomain(row);
+      // Convert database record to domain entity
+      return this.mapper.toDomain(result[0]);
     } catch (error) {
       logger.error('Error finding platform user by platform and external ID in SQLite repository', {
         error: error instanceof Error ? error.message : String(error),
@@ -137,37 +113,31 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
         return null;
       }
 
-      // Create a merged entity
+      // Create a merged entity with updated timestamp
       const mergedUser = PlatformUser.create({
         ...existingUser.toObject(),
         ...user as Partial<PlatformUser>,
         updatedAt: new Date()
       });
-      const obj = mergedUser.toObject();
 
-      // Convert metadata to JSON string if it exists
-      const metadata = obj.metadata ? JSON.stringify(obj.metadata) : null;
+      // Convert domain entity to database record
+      const record = this.mapper.toPersistence(mergedUser);
 
-      // Update in database
-      this.db.prepare(`
-        UPDATE platform_users SET
-          platformId = ?,
-          externalUserId = ?,
-          displayName = ?,
-          email = ?,
-          metadata = ?,
-          updatedAt = ?
-        WHERE id = ?
-      `).run(
-        String(obj.platformId),
-        String(obj.externalUserId),
-        obj.displayName ? String(obj.displayName) : null,
-        obj.email ? String(obj.email) : null,
-        metadata,
-        (obj.updatedAt instanceof Date) ? obj.updatedAt.toISOString() : String(obj.updatedAt),
-        String(id)
-      );
+      // Update in database using Drizzle ORM
+      const result = await this.db
+        .update(platformUsers)
+        .set({
+          platformId: record.platformId,
+          externalUserId: record.externalUserId,
+          displayName: record.displayName,
+          email: record.email,
+          metadata: record.metadata,
+          updatedAt: record.updatedAt
+        })
+        .where(eq(platformUsers.id, id as string))
+        .returning();
 
+      // Return the updated entity
       return mergedUser;
     } catch (error) {
       logger.error('Error updating platform user in SQLite repository', {
@@ -181,11 +151,14 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
 
   async delete(id: Shared.IRI): Promise<boolean> {
     try {
-      // Delete from database
-      const result = this.db.prepare(`DELETE FROM platform_users WHERE id = ?`).run(id);
+      // Delete from database using Drizzle ORM
+      const result = await this.db
+        .delete(platformUsers)
+        .where(eq(platformUsers.id, id as string))
+        .returning();
 
       // Return true if something was deleted
-      return result.changes > 0;
+      return result.length > 0;
     } catch (error) {
       logger.error('Error deleting platform user in SQLite repository', {
         error: error instanceof Error ? error.message : String(error),
@@ -193,64 +166,5 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       });
       throw error;
     }
-  }
-
-  /**
-   * Converts a database row to a domain entity
-   * @param row The database row
-   * @returns A PlatformUser domain entity
-   */
-  private rowToDomain(row: SqlitePlatformUserRecord): PlatformUser {
-    // Validate required fields from DB
-    if (!row.id) {
-      throw new Error('Platform user record is missing required field: id');
-    }
-    if (!row.platformId) {
-      throw new Error('Platform user record is missing required field: platformId');
-    }
-    if (!row.externalUserId) {
-      throw new Error(
-        'Platform user record is missing required field: externalUserId'
-      );
-    }
-    if (!row.createdAt) {
-      throw new Error('Platform user record is missing required field: createdAt');
-    }
-    if (!row.updatedAt) {
-      throw new Error('Platform user record is missing required field: updatedAt');
-    }
-
-    // Safely parse metadata
-    let metadata: Record<string, unknown> | undefined = undefined;
-    if (row.metadata !== null && row.metadata !== undefined) {
-      try {
-        const parsed = convertJson<Record<string, unknown>>(
-          row.metadata,
-          'sqlite',
-          'from'
-        );
-        if (parsed && typeof parsed === 'object') {
-          metadata = parsed;
-        }
-      } catch (error) {
-        logger.warn('Error parsing platform user metadata', {
-          error: error instanceof Error ? error.message : String(error),
-          metadata: row.metadata,
-          userId: row.id,
-        });
-        // Decide whether to throw or continue with undefined metadata
-      }
-    }
-
-    return PlatformUser.create({
-      id: convertUuid(row.id, 'sqlite', 'from') as Shared.IRI,
-      platformId: convertUuid(row.platformId, 'sqlite', 'from') as Shared.IRI,
-      externalUserId: row.externalUserId, // Already validated non-null
-      displayName: row.displayName, // Optional field
-      email: row.email, // Optional field
-      metadata,
-      createdAt: new Date(convertTimestamp(row.createdAt, 'sqlite', 'from') as number), // Validated non-null
-      updatedAt: new Date(convertTimestamp(row.updatedAt, 'sqlite', 'from') as number), // Validated non-null
-    });
   }
 }

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
@@ -44,7 +44,7 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       return newUser;
     } catch (error) {
       logger.error('Error creating platform user in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         user
       });
       throw error;
@@ -68,7 +68,7 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       return this.mapper.toDomain(result[0]);
     } catch (error) {
       logger.error('Error finding platform user by ID in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         id
       });
       throw error;
@@ -97,7 +97,7 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       return this.mapper.toDomain(result[0]);
     } catch (error) {
       logger.error('Error finding platform user by platform and external ID in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         platformId,
         externalUserId
       });
@@ -123,25 +123,15 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       // Convert domain entity to database record
       const record = this.mapper.toPersistence(mergedUser);
 
-      // Prepare update data with required fields
+      // Prepare update data with all fields, including optional ones with null handling
       const updateData: Record<string, unknown> = {
         platformId: record.platformId,
         externalUserId: record.externalUserId,
-        updatedAt: record.updatedAt
+        updatedAt: record.updatedAt,
+        displayName: record.displayName ?? null,
+        email: record.email ?? null,
+        metadata: record.metadata ?? null
       };
-
-      // Add optional fields if they exist in the record
-      if ('displayName' in record) {
-        updateData.displayName = record.displayName;
-      }
-
-      if ('email' in record) {
-        updateData.email = record.email;
-      }
-
-      if ('metadata' in record) {
-        updateData.metadata = record.metadata;
-      }
 
       // Update in database using Drizzle ORM
       await this.db
@@ -154,7 +144,7 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       return mergedUser;
     } catch (error) {
       logger.error('Error updating platform user in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         id,
         user
       });
@@ -174,7 +164,7 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       return result.length > 0;
     } catch (error) {
       logger.error('Error deleting platform user in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         id
       });
       throw error;

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
@@ -5,7 +5,7 @@
  * and the Data Mapper pattern with Drizzle ORM.
  */
 
-import { eq, and, InferInsertModel } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
 import { PlatformUser } from '@domains/backpack/platform-user.entity';
@@ -35,7 +35,7 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       const record = this.mapper.toPersistence(newUser);
 
       // Insert into database
-      const result = await this.db
+      await this.db
         .insert(platformUsers)
         .values(record)
         .returning();
@@ -124,7 +124,7 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       const record = this.mapper.toPersistence(mergedUser);
 
       // Update in database using Drizzle ORM
-      const result = await this.db
+      await this.db
         .update(platformUsers)
         .set({
           platformId: record.platformId,

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
@@ -123,15 +123,26 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
       // Convert domain entity to database record
       const record = this.mapper.toPersistence(mergedUser);
 
-      // Prepare update data with all fields, including optional ones with null handling
+      // Prepare update data with required fields
       const updateData: Record<string, unknown> = {
         platformId: record.platformId,
         externalUserId: record.externalUserId,
-        updatedAt: record.updatedAt,
-        displayName: record.displayName ?? null,
-        email: record.email ?? null,
-        metadata: record.metadata ?? null
+        updatedAt: record.updatedAt
       };
+
+      // Add optional fields with null handling
+      const extendedRecord = record as Record<string, unknown>;
+      if ('displayName' in extendedRecord) {
+        updateData.displayName = extendedRecord.displayName ?? null;
+      }
+
+      if ('email' in extendedRecord) {
+        updateData.email = extendedRecord.email ?? null;
+      }
+
+      if ('metadata' in extendedRecord) {
+        updateData.metadata = extendedRecord.metadata ?? null;
+      }
 
       // Update in database using Drizzle ORM
       await this.db

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-platform-user.repository.ts
@@ -129,9 +129,10 @@ export class SqlitePlatformUserRepository implements PlatformUserRepository {
         .set({
           platformId: record.platformId,
           externalUserId: record.externalUserId,
-          displayName: record.displayName,
-          email: record.email,
-          metadata: record.metadata,
+          // Only include optional fields if they exist in the record
+          ...(record.displayName !== undefined ? { displayName: record.displayName } : {}),
+          ...(record.email !== undefined ? { email: record.email } : {}),
+          ...(record.metadata !== undefined ? { metadata: record.metadata } : {}),
           updatedAt: record.updatedAt
         })
         .where(eq(platformUsers.id, id as string))

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
@@ -75,11 +75,11 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       const extendedRecord = record as Record<string, unknown>;
 
       if ('status' in extendedRecord && extendedRecord.status !== undefined) {
-        updateData.status = extendedRecord.status as string;
+        updateData.status = String(extendedRecord.status);
       }
 
       if ('metadata' in extendedRecord && extendedRecord.metadata !== undefined) {
-        updateData.metadata = extendedRecord.metadata as string;
+        updateData.metadata = String(extendedRecord.metadata);
       }
 
       // Define a properly typed update object for Drizzle
@@ -89,11 +89,11 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       const drizzleUpdateSet: DrizzleUpdateSet = {};
 
       if (updateData.status !== undefined) {
-        drizzleUpdateSet[userAssertions.status.name] = updateData.status;
+        drizzleUpdateSet[userAssertions.status.name] = String(updateData.status);
       }
 
       if (updateData.metadata !== undefined) {
-        drizzleUpdateSet[userAssertions.metadata.name] = updateData.metadata;
+        drizzleUpdateSet[userAssertions.metadata.name] = String(updateData.metadata);
       }
 
       await this.db

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
@@ -82,8 +82,11 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
         updateData.metadata = extendedRecord.metadata as string;
       }
 
-      // Create a properly typed update object for Drizzle
-      const drizzleUpdateSet: Record<string, unknown> = {};
+      // Define a properly typed update object for Drizzle
+      type DrizzleUpdateSet = {
+        [key in typeof userAssertions.status.name | typeof userAssertions.metadata.name]?: string;
+      };
+      const drizzleUpdateSet: DrizzleUpdateSet = {};
 
       if (updateData.status !== undefined) {
         drizzleUpdateSet[userAssertions.status.name] = updateData.status;
@@ -106,7 +109,7 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       return userAssertion;
     } catch (error) {
       logger.error('Error creating user assertion in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         userId,
         assertionId
       });
@@ -131,7 +134,7 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       return result.length > 0;
     } catch (error) {
       logger.error('Error removing assertion from user in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         userId,
         assertionId
       });
@@ -142,8 +145,11 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
   async updateStatus(userId: Shared.IRI, assertionId: Shared.IRI, status: UserAssertionStatus): Promise<boolean> {
     try {
       // Update status in database using Drizzle ORM
-      // Create a properly typed update object for Drizzle
-      const drizzleUpdateSet: Record<string, unknown> = {};
+      // Define a properly typed update object for Drizzle
+      type DrizzleUpdateSet = {
+        [key in typeof userAssertions.status.name]?: string;
+      };
+      const drizzleUpdateSet: DrizzleUpdateSet = {};
       drizzleUpdateSet[userAssertions.status.name] = String(status);
 
       const result = await this.db
@@ -161,7 +167,7 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       return result.length > 0;
     } catch (error) {
       logger.error('Error updating assertion status in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         userId,
         assertionId,
         status
@@ -207,7 +213,7 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       return result.map(record => this.mapper.toDomain(record));
     } catch (error) {
       logger.error('Error getting user assertions in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         userId,
         params
       });
@@ -227,7 +233,7 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       return result.map(record => this.mapper.toDomain(record));
     } catch (error) {
       logger.error('Error getting assertion users in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         assertionId
       });
       throw error;
@@ -252,7 +258,7 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       return result.length > 0;
     } catch (error) {
       logger.error('Error checking if user has assertion in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         userId,
         assertionId
       });
@@ -282,7 +288,7 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       return this.mapper.toDomain(result[0]);
     } catch (error) {
       logger.error('Error finding user assertion by user and assertion ID in SQLite repository', {
-        error: error instanceof Error ? error.message : String(error),
+        error: error instanceof Error ? error.stack : String(error),
         userId,
         assertionId
       });

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
@@ -74,22 +74,22 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       // Add fields to update if they exist
       const extendedRecord = record as Record<string, unknown>;
 
-      if ('status' in extendedRecord || extendedRecord.status) {
+      if ('status' in extendedRecord && extendedRecord.status !== undefined) {
         updateData.status = extendedRecord.status as string;
       }
 
-      if ('metadata' in extendedRecord || extendedRecord.metadata) {
+      if ('metadata' in extendedRecord && extendedRecord.metadata !== undefined) {
         updateData.metadata = extendedRecord.metadata as string;
       }
 
       // Create a properly typed update object for Drizzle
       const drizzleUpdateSet: Record<string, unknown> = {};
 
-      if (updateData.status) {
+      if (updateData.status !== undefined) {
         drizzleUpdateSet[userAssertions.status.name] = updateData.status;
       }
 
-      if (updateData.metadata) {
+      if (updateData.metadata !== undefined) {
         drizzleUpdateSet[userAssertions.metadata.name] = updateData.metadata;
       }
 

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
@@ -2,8 +2,11 @@
  * SQLite implementation of the UserAssertion repository
  *
  * This class implements the UserAssertionRepository interface using SQLite
+ * and the Data Mapper pattern with Drizzle ORM.
  */
 
+import { eq, and, ne, sql, InferInsertModel } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
 import { UserAssertion } from '@domains/backpack/user-assertion.entity';
 import type { UserAssertionRepository } from '@domains/backpack/user-assertion.repository';
@@ -11,31 +14,17 @@ import { Shared } from 'openbadges-types';
 import { logger } from '@utils/logging/logger.service';
 import { UserAssertionStatus } from '@domains/backpack/backpack.types';
 import { UserAssertionCreateParams, UserAssertionQueryParams } from '@domains/backpack/repository.types';
+import { userAssertions } from '../schema';
+import { SqliteUserAssertionMapper } from '../mappers/sqlite-user-assertion.mapper';
+import { createId } from '@paralleldrive/cuid2';
 
 export class SqliteUserAssertionRepository implements UserAssertionRepository {
-  private db: Database;
+  private db: ReturnType<typeof drizzle>;
+  private mapper: SqliteUserAssertionMapper;
 
-  constructor(db: Database) {
-    this.db = db;
-
-    // Create the user_assertions table if it doesn't exist
-    this.db.run(`
-      CREATE TABLE IF NOT EXISTS user_assertions (
-        id TEXT PRIMARY KEY,
-        userId TEXT NOT NULL,
-        assertionId TEXT NOT NULL,
-        addedAt TEXT NOT NULL,
-        status TEXT NOT NULL,
-        metadata TEXT,
-        FOREIGN KEY (userId) REFERENCES platform_users(id) ON DELETE CASCADE,
-        FOREIGN KEY (assertionId) REFERENCES assertions(id) ON DELETE CASCADE,
-        UNIQUE (userId, assertionId)
-      )
-    `);
-
-    // Create indexes
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_user_assertions_user ON user_assertions(userId)`);
-    this.db.run(`CREATE INDEX IF NOT EXISTS idx_user_assertions_assertion ON user_assertions(assertionId)`);
+  constructor(client: Database) {
+    this.db = drizzle(client);
+    this.mapper = new SqliteUserAssertionMapper();
   }
 
   async addAssertion(userIdOrParams: Shared.IRI | UserAssertionCreateParams, assertionId?: Shared.IRI, metadata?: Record<string, unknown>): Promise<UserAssertion> {
@@ -66,51 +55,59 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
    * Internal method to create a user assertion
    */
   private async createUserAssertion(userId: Shared.IRI, assertionId: Shared.IRI, metadata?: Record<string, unknown>): Promise<UserAssertion> {
-
-      // Create a new user assertion entity
+    try {
+      // Create a new user assertion entity with a generated ID
+      const id = createId() as Shared.IRI;
       const userAssertion = UserAssertion.create({
+        id,
         userId,
         assertionId,
         metadata
       });
-      const obj = userAssertion.toObject();
 
-      // Convert metadata to JSON string if it exists
-      const metadataStr = obj.metadata ? JSON.stringify(obj.metadata) : null;
+      // Convert domain entity to database record
+      const record = this.mapper.toPersistence(userAssertion);
 
-      // Insert into database
-      this.db.prepare(`
-        INSERT INTO user_assertions (
-          id, userId, assertionId, addedAt, status, metadata
-        ) VALUES (?, ?, ?, ?, ?, ?)
-        ON CONFLICT (userId, assertionId) DO UPDATE SET
-          status = ?,
-          metadata = ?
-      `).run(
-        String(obj.id),
-        String(obj.userId),
-        String(obj.assertionId),
-        (obj.addedAt instanceof Date) ? obj.addedAt.toISOString() : String(obj.addedAt),
-        String(obj.status),
-        metadataStr,
-        String(obj.status),
-        metadataStr
-      );
+      // Insert into database with ON CONFLICT DO UPDATE
+      const result = await this.db
+        .insert(userAssertions)
+        .values(record)
+        .onConflictDoUpdate({
+          target: [userAssertions.userId, userAssertions.assertionId],
+          set: {
+            status: record.status,
+            metadata: record.metadata
+          }
+        })
+        .returning();
 
+      // Return the domain entity
       return userAssertion;
-
+    } catch (error) {
+      logger.error('Error creating user assertion in SQLite repository', {
+        error: error instanceof Error ? error.message : String(error),
+        userId,
+        assertionId
+      });
+      throw error;
+    }
   }
 
   async removeAssertion(userId: Shared.IRI, assertionId: Shared.IRI): Promise<boolean> {
     try {
-      // Delete from database
-      const result = this.db.prepare(`
-        DELETE FROM user_assertions
-        WHERE userId = ? AND assertionId = ?
-      `).run(String(userId), String(assertionId));
+      // Delete from database using Drizzle ORM
+      const result = await this.db
+        .delete(userAssertions)
+        .where(
+          and(
+            eq(userAssertions.userId, userId as string),
+            eq(userAssertions.assertionId, assertionId as string)
+          )
+        )
+        .returning();
 
       // Return true if something was deleted
-      return result.changes > 0;
+      return result.length > 0;
     } catch (error) {
       logger.error('Error removing assertion from user in SQLite repository', {
         error: error instanceof Error ? error.message : String(error),
@@ -123,15 +120,20 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
 
   async updateStatus(userId: Shared.IRI, assertionId: Shared.IRI, status: UserAssertionStatus): Promise<boolean> {
     try {
-      // Update status in database
-      const result = this.db.prepare(`
-        UPDATE user_assertions
-        SET status = ?
-        WHERE userId = ? AND assertionId = ?
-      `).run(String(status), String(userId), String(assertionId));
+      // Update status in database using Drizzle ORM
+      const result = await this.db
+        .update(userAssertions)
+        .set({ status: status as string })
+        .where(
+          and(
+            eq(userAssertions.userId, userId as string),
+            eq(userAssertions.assertionId, assertionId as string)
+          )
+        )
+        .returning();
 
       // Return true if something was updated
-      return result.changes > 0;
+      return result.length > 0;
     } catch (error) {
       logger.error('Error updating assertion status in SQLite repository', {
         error: error instanceof Error ? error.message : String(error),
@@ -145,38 +147,38 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
 
   async getUserAssertions(userId: Shared.IRI, params?: UserAssertionQueryParams): Promise<UserAssertion[]> {
     try {
-      // Build query
-      let query = `SELECT * FROM user_assertions WHERE userId = ? AND status != ?`;
-      const queryParams: (string | number | boolean)[] = [String(userId), String(UserAssertionStatus.DELETED)];
+      // Build the where conditions
+      const whereCondition = params?.status
+        ? and(
+            eq(userAssertions.userId, userId as string),
+            eq(userAssertions.status, params.status as string)
+          )
+        : and(
+            eq(userAssertions.userId, userId as string),
+            ne(userAssertions.status, UserAssertionStatus.DELETED as string)
+          );
 
-      // Add filters if provided
-      if (params) {
-        if (params.status) {
-          query = query.replace('AND status != ?', 'AND status = ?');
-          queryParams[1] = String(params.status);
-        }
+      // Build the query with the condition
+      let query = this.db.select().from(userAssertions).where(whereCondition);
 
-        // Add limit and offset if provided
-        if (params.limit) {
-          query += ` LIMIT ?`;
-          queryParams.push(params.limit);
-
-          if (params.offset) {
-            query += ` OFFSET ?`;
-            queryParams.push(params.offset);
-          }
+      // Apply pagination if provided
+      if (params?.limit !== undefined) {
+        query = query.limit(params.limit);
+        if (params.offset !== undefined) {
+          query = query.offset(params.offset);
         }
       }
 
-      // Query database
-      const rows = this.db.prepare(query).all(...queryParams);
+      // Execute the query
+      const result = await query;
 
-      // Convert rows to domain entities
-      return rows.map(row => this.rowToDomain(row as Record<string, unknown>));
+      // Convert database records to domain entities
+      return result.map(record => this.mapper.toDomain(record));
     } catch (error) {
       logger.error('Error getting user assertions in SQLite repository', {
         error: error instanceof Error ? error.message : String(error),
-        userId
+        userId,
+        params
       });
       throw error;
     }
@@ -184,14 +186,14 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
 
   async getAssertionUsers(assertionId: Shared.IRI): Promise<UserAssertion[]> {
     try {
-      // Query database
-      const rows = this.db.prepare(`
-        SELECT * FROM user_assertions
-        WHERE assertionId = ?
-      `).all(String(assertionId));
+      // Query database using Drizzle ORM
+      const result = await this.db
+        .select()
+        .from(userAssertions)
+        .where(eq(userAssertions.assertionId, assertionId as string));
 
-      // Convert rows to domain entities
-      return rows.map(row => this.rowToDomain(row as Record<string, unknown>));
+      // Convert database records to domain entities
+      return result.map(record => this.mapper.toDomain(record));
     } catch (error) {
       logger.error('Error getting assertion users in SQLite repository', {
         error: error instanceof Error ? error.message : String(error),
@@ -203,14 +205,20 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
 
   async hasAssertion(userId: Shared.IRI, assertionId: Shared.IRI): Promise<boolean> {
     try {
-      // Query database
-      const row = this.db.prepare(`
-        SELECT 1 FROM user_assertions
-        WHERE userId = ? AND assertionId = ? AND status != ?
-      `).get(String(userId), String(assertionId), String(UserAssertionStatus.DELETED));
+      // Query database using Drizzle ORM
+      const result = await this.db
+        .select({ exists: sql`1` })
+        .from(userAssertions)
+        .where(
+          and(
+            eq(userAssertions.userId, userId as string),
+            eq(userAssertions.assertionId, assertionId as string),
+            ne(userAssertions.status, UserAssertionStatus.DELETED as string)
+          )
+        );
 
       // Return true if found
-      return !!row;
+      return result.length > 0;
     } catch (error) {
       logger.error('Error checking if user has assertion in SQLite repository', {
         error: error instanceof Error ? error.message : String(error),
@@ -223,17 +231,24 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
 
   async findByUserAndAssertion(userId: Shared.IRI, assertionId: Shared.IRI): Promise<UserAssertion | null> {
     try {
-      // Query database
-      const row = this.db.prepare(`
-        SELECT * FROM user_assertions
-        WHERE userId = ? AND assertionId = ?
-      `).get(String(userId), String(assertionId));
+      // Query database using Drizzle ORM
+      const result = await this.db
+        .select()
+        .from(userAssertions)
+        .where(
+          and(
+            eq(userAssertions.userId, userId as string),
+            eq(userAssertions.assertionId, assertionId as string)
+          )
+        );
 
-      if (!row) {
+      // Return null if not found
+      if (!result.length) {
         return null;
       }
 
-      return this.rowToDomain(row as Record<string, unknown>);
+      // Convert database record to domain entity
+      return this.mapper.toDomain(result[0]);
     } catch (error) {
       logger.error('Error finding user assertion by user and assertion ID in SQLite repository', {
         error: error instanceof Error ? error.message : String(error),
@@ -242,37 +257,5 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       });
       throw error;
     }
-  }
-
-  /**
-   * Converts a database row to a domain entity
-   * @param row The database row
-   * @returns A UserAssertion domain entity
-   */
-  private rowToDomain(row: Record<string, unknown>): UserAssertion {
-    // Parse metadata if it exists
-    let metadata: Record<string, unknown> | undefined;
-    if (row.metadata && typeof row.metadata === 'string') {
-      try {
-        const parsedMetadata = JSON.parse(row.metadata);
-        // Ensure the parsed data is a non-null object before assigning
-        if (parsedMetadata && typeof parsedMetadata === 'object') {
-          metadata = parsedMetadata as Record<string, unknown>; // Cast after check
-        } else {
-          logger.warn('Parsed user assertion metadata is not an object', { metadataValue: row.metadata });
-        }
-      } catch (error) {
-        logger.warn('Failed to parse user assertion metadata', { error });
-      }
-    }
-
-    return UserAssertion.create({
-      id: typeof row.id === 'string' ? row.id as Shared.IRI : String(row.id) as Shared.IRI,
-      userId: typeof row.userId === 'string' ? row.userId as Shared.IRI : String(row.userId) as Shared.IRI,
-      assertionId: typeof row.assertionId === 'string' ? row.assertionId as Shared.IRI : String(row.assertionId) as Shared.IRI,
-      addedAt: typeof row.addedAt === 'string' || typeof row.addedAt === 'number' ? new Date(row.addedAt) : new Date(),
-      status: typeof row.status === 'string' ? row.status as UserAssertionStatus : UserAssertionStatus.ACTIVE,
-      metadata
-    });
   }
 }

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
@@ -17,7 +17,6 @@ import { UserAssertionCreateParams, UserAssertionQueryParams } from '@domains/ba
 import { userAssertions } from '../schema';
 import { SqliteUserAssertionMapper } from '../mappers/sqlite-user-assertion.mapper';
 import { createId } from '@paralleldrive/cuid2';
-import { InferInsertModel } from 'drizzle-orm';
 
 export class SqliteUserAssertionRepository implements UserAssertionRepository {
   private db: ReturnType<typeof drizzle>;

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
@@ -5,7 +5,7 @@
  * and the Data Mapper pattern with Drizzle ORM.
  */
 
-import { eq, and, ne, sql, InferInsertModel } from 'drizzle-orm';
+import { eq, and, ne, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
 import { Database } from 'bun:sqlite';
 import { UserAssertion } from '@domains/backpack/user-assertion.entity';
@@ -69,7 +69,7 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       const record = this.mapper.toPersistence(userAssertion);
 
       // Insert into database with ON CONFLICT DO UPDATE
-      const result = await this.db
+      await this.db
         .insert(userAssertions)
         .values(record)
         .onConflictDoUpdate({

--- a/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
+++ b/src/infrastructure/database/modules/sqlite/repositories/sqlite-user-assertion.repository.ts
@@ -205,18 +205,24 @@ export class SqliteUserAssertionRepository implements UserAssertionRepository {
       // Execute the query with pagination if provided
       let result;
 
-      // Apply limit if provided
+      // Apply pagination if provided
       if (params?.limit !== undefined) {
-        query = query.limit(params.limit);
-      }
+        // Create a new query with limit
+        const limitQuery = query.limit(params.limit);
 
-      // Apply offset if provided (even if limit is not provided)
-      if (params?.offset !== undefined) {
-        query = query.offset(params.offset);
+        // Add offset if provided
+        if (params?.offset !== undefined) {
+          result = await limitQuery.offset(params.offset);
+        } else {
+          result = await limitQuery;
+        }
+      } else if (params?.offset !== undefined) {
+        // If only offset is provided (unusual but supported)
+        result = await query.offset(params.offset);
+      } else {
+        // Execute without pagination
+        result = await query;
       }
-
-      // Execute the query
-      result = await query;
 
       // Convert database records to domain entities
       return result.map(record => this.mapper.toDomain(record));


### PR DESCRIPTION
## Description

This PR refactors the SQLite repositories to use Drizzle ORM consistently, removing manual SQL/table creation and ensuring the use of type conversion utilities. This addresses issue #52.

## Changes

- Refactored `SqliteUserAssertionRepository` to use Drizzle ORM instead of direct SQLite calls
- Refactored `SqlitePlatformUserRepository` to use Drizzle ORM instead of direct SQLite calls
- Created mapper classes for consistent domain entity conversion
- Removed manual SQL table creation code
- Ensured proper use of type conversion utilities
- Fixed TypeScript and ESLint errors

## Testing

All tests are passing. The refactored repositories maintain the same functionality while using a consistent data access pattern.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author