### PR TITLE
Fix: Update Release Pipeline Configuration

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,61 @@
+# GitHub Workflows
+
+This directory contains GitHub Actions workflow configurations for the Open Badges Modular Server project.
+
+## Workflows
+
+### Release Workflow (`release.yml`)
+
+The release workflow is triggered when code is pushed to the `main` branch. It uses [semantic-release](https://github.com/semantic-release/semantic-release) to automate the versioning and release process.
+
+#### Configuration
+
+- **Trigger**: Push to `main` branch
+- **Permissions**: Write access to contents, issues, and pull requests
+- **Steps**:
+  1. Checkout the repository with full history
+  2. Set up Node.js and Bun
+  3. Install dependencies
+  4. Run tests
+  5. Build the application
+  6. Run semantic-release to create a new release
+
+#### Environment Variables
+
+- `GH_TOKEN`: GitHub token for authentication (provided by GitHub Actions)
+- `NPM_TOKEN`: A dummy token to satisfy semantic-release requirements (not used for actual publishing)
+
+### Semantic Release Configuration
+
+The semantic-release configuration is defined in `.releaserc.json` at the root of the repository. It uses the following plugins:
+
+- `@semantic-release/commit-analyzer`: Analyzes commit messages to determine the next version
+- `@semantic-release/release-notes-generator`: Generates release notes based on commit messages
+- `@semantic-release/changelog`: Updates the CHANGELOG.md file
+- `@semantic-release/npm`: Updates the version in package.json (does not publish to NPM)
+- `@semantic-release/git`: Commits the updated files back to the repository
+- `@semantic-release/github`: Creates a GitHub release
+
+#### Important Notes
+
+1. The `@semantic-release/npm` plugin is configured with `npmPublish: false` since we're not publishing to NPM.
+2. We're using a dummy NPM token to satisfy semantic-release requirements.
+3. The release workflow uses `persist-credentials: true` to allow semantic-release to push changes back to the repository.
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Release not created**: Check if your commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
+2. **Authentication errors**: Ensure the workflow has the correct permissions set.
+3. **NPM publishing errors**: These should not occur since we've disabled NPM publishing.
+
+### Debugging
+
+To debug the release process locally, you can run:
+
+```bash
+bun run release:dry-run
+```
+
+This will show what would happen during a release without making any changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          # Allow semantic-release to push changes back to the repository
+          persist-credentials: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -56,6 +58,8 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Use GH_TOKEN instead of GITHUB_TOKEN for better compatibility with semantic-release
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Set a dummy NPM_TOKEN to satisfy semantic-release requirements
+          NPM_TOKEN: "dummy-token"
         run: bun run semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -9,7 +9,12 @@
         "changelogFile": "CHANGELOG.md"
       }
     ],
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
     [
       "@semantic-release/git",
       {

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -19,8 +19,15 @@ Releases are automatically created when code is merged to the `main` branch. The
    - Updates the `CHANGELOG.md` file
    - Creates a git tag for the release
    - Creates a GitHub release with release notes
+   - Triggers the Docker image build and push workflow (via the tag creation)
 
 > **Note**: The version field in `package.json` is managed automatically by semantic-release. You should never manually modify this value as it will be overwritten during the release process.
+
+### Docker Image Release
+
+When a new version is released, a Docker image is automatically built and pushed to the GitHub Container Registry. The image is tagged with the version number and is available at `ghcr.io/rollercoaster-dev/openbadges-modular-server:<version>`.
+
+The Docker image build is triggered by the creation of a tag by semantic-release. The tag follows the format `v<version>` (e.g., `v1.0.0`).
 
 ## Manual Releases
 
@@ -113,6 +120,20 @@ If a release is not created when you expect it to be, check:
 2. Are you on the `main` branch?
 3. Has there been any change since the last release?
 4. Check the GitHub Actions logs for errors.
+
+### NPM-Related Errors
+
+If you see errors related to NPM publishing, check:
+
+1. The `.releaserc.json` file should have the `@semantic-release/npm` plugin configured with `npmPublish: false`.
+2. The release workflow should have a dummy NPM token set in the environment variables.
+
+### Git Authentication Errors
+
+If you see errors related to Git authentication, check:
+
+1. The checkout action in the release workflow should have `persist-credentials: true`.
+2. The workflow should have the correct permissions set (`contents: write`, `issues: write`, `pull-requests: write`).
 
 ### Manual Release Failed
 


### PR DESCRIPTION
This PR fixes the failing release pipeline by addressing the following issues:

1. **Git Authentication**: Updated the checkout action to use `persist-credentials: true` to allow semantic-release to push changes back to the repository.

2. **NPM Token**: Added a dummy NPM token to satisfy semantic-release requirements, as we're not actually publishing to NPM.

3. **Semantic Release Configuration**: Updated the `.releaserc.json` configuration to set `npmPublish: false` for the `@semantic-release/npm` plugin.

4. **Documentation**: Added detailed documentation about the release process and troubleshooting in `.github/README.md` and updated `docs/release-process.md`.

These changes should resolve the authentication and NPM-related issues in the release pipeline.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author