### PR TITLE
fix: enable semantic-release production mode

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,6 +13,6 @@
     }],
     "@semantic-release/github"
   ],
-  "dryRun": true,
-  "ci": false
+  "dryRun": false,
+  "ci": true
 }


### PR DESCRIPTION
## 🎯 Problem
The Release workflow was completing successfully but **no releases were being created** because semantic-release was configured in **dry-run mode**.

## 🔍 Root Cause
The  configuration had:


This explains why:
- ✅ **Release workflow runs successfully** (no errors)
- ❌ **No actual release is created** (dry-run mode)
- ✅ **Tests pass and build works** (workflow completes)

## ✅ Solution
Updated  to enable production mode:


## 📊 Expected Results
After merging this PR:
- ✅ **Release workflow will create actual releases**
- ✅ **Semantic versioning will work properly**
- ✅ **GitHub releases will be generated automatically**
- ✅ **Changelog will be updated**
- ✅ **Version tags will be created**

## 🧪 Testing
- [x] Local testing confirms configuration is valid
- [x] Pre-push hooks passed (770 tests, 0 failures)
- [x] Linting and type checking passed

## 🚀 Impact
This fixes the core issue where the Release workflow appeared to work but was actually running in test mode. Once merged, the next commit to main will trigger an actual release creation.

Fixes: Release workflow completing successfully but creating no releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release process configuration to enable actual publishing and continuous integration mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->