### PR TITLE
feat: replace PAT_TOKEN with GitHub App authentication

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -337,7 +337,11 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Use GitHub App token for git push - bypasses branch protection for release commits
-          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git
+          # Keep the remote URL token-free to avoid accidental leakage in debug output
+          git remote set-url origin https://github.com/${{ github.repository }}.git
+          export GIT_ASKPASS=$(mktemp)
+          echo "echo '${{ steps.app-token.outputs.token }}'" > $GIT_ASKPASS
+          chmod +x $GIT_ASKPASS
 
       - name: Release
         id: semantic
@@ -412,7 +416,7 @@ jobs:
           echo "Re-enabling admin enforcement for branch protection"
           curl -X POST \
             -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
-            -H "Accept: application/vnd.github.v3+json" \
+            -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/branches/main/protection/enforce_admins" \
             -d '{"enabled": true}' || echo "Failed to re-enable admin enforcement (may already be enabled)"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ concurrency:
 env:
   NODE_VERSION: '20'
   BUN_VERSION: 'latest'
-  GH_PAT: ${{ secrets.PAT_TOKEN }}
 
 jobs:
   # Stage 1: Code Quality & Fast Tests
@@ -305,12 +304,19 @@ jobs:
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
 
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-          # Use PAT_TOKEN for checkout to prevent lingering GITHUB_TOKEN headers
-          token: ${{ secrets.PAT_TOKEN }}
+          # Use GitHub App token for checkout to prevent lingering GITHUB_TOKEN headers
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
 
       - name: Setup Bun
@@ -330,14 +336,14 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Use PAT_TOKEN for git push - bypasses branch protection for release commits
-          git remote set-url origin https://x-access-token:${{ secrets.PAT_TOKEN }}@github.com/${{ github.repository }}.git
+          # Use GitHub App token for git push - bypasses branch protection for release commits
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git
 
       - name: Release
         id: semantic
         env:
-          # Use PAT_TOKEN for semantic-release - bypasses branch protection for release commits
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          # Use GitHub App token for semantic-release - bypasses branch protection for release commits
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: dummy
         run: |
           set -euo pipefail  # Exit on error, undefined vars, pipe failures
@@ -405,7 +411,7 @@ jobs:
         run: |
           echo "Re-enabling admin enforcement for branch protection"
           curl -X POST \
-            -H "Authorization: token ${{ secrets.PAT_TOKEN }}" \
+            -H "Authorization: token ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/branches/main/protection/enforce_admins" \
             -d '{"enabled": true}' || echo "Failed to re-enable admin enforcement (may already be enabled)"


### PR DESCRIPTION
## Summary

This PR replaces the PAT_TOKEN-based authentication in our CI/CD workflow with GitHub App authentication for improved security and reliability.

## Changes

- ✅ **Replace PAT_TOKEN with GitHub App token generation** using 
- ✅ **Update all workflow steps** to use the generated app token instead of PAT_TOKEN
- ✅ **Remove GH_PAT environment variable** as it's no longer needed
- ✅ **Improve security** by using short-lived, scoped tokens instead of personal access tokens

## Benefits

🔒 **More secure** - tokens are short-lived and scoped to specific permissions
�� **No personal dependency** - not tied to any individual's personal account  
⚡ **Better rate limits** - GitHub Apps get higher API rate limits
🔄 **Auto-renewal** - tokens are automatically refreshed

## Requirements

This change requires the following repository secrets to be configured:
-  - The GitHub App ID ✅ **Already configured**
-  - The GitHub App private key ✅ **Already configured**

## Testing

- ✅ All tests pass locally
- ✅ Pre-push hooks pass (lint, typecheck, tests)
- 🔄 Will test GitHub App authentication when this PR is merged

## Related Issues

This addresses the recurring PAT_TOKEN authentication issues we've been experiencing in our release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to use a GitHub App token for authentication instead of a personal access token.
  * Improved security and reliability of release process authentication.
  * Enhanced workflow to eliminate token-related errors and streamline release operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->