### PR TITLE
fix: configure git URL rewriting for semantic-release authentication

### DIFF
--- a/.augment/working/tasks/todo/ci-release-systematic-fix.md
+++ b/.augment/working/tasks/todo/ci-release-systematic-fix.md
@@ -384,6 +384,50 @@ chmod +x $GIT_ASKPASS
 - ✅ **Scoped permissions**: Only required permissions granted
 - ✅ **Modern API headers**: Using current GitHub API recommendations
 
+## PHASE 5: Critical Git Push Authentication Issue ❌ FAILED
+
+### PROBLEM IDENTIFIED: Semantic-Release Git Plugin Bypass
+**Root Cause**: The `@semantic-release/git` plugin is bypassing our GIT_ASKPASS configuration and using its own git push command with token-in-URL approach.
+
+### Error Analysis from Run #75 (ID: 16239919205)
+**Failed Command**:
+```bash
+git push --tags https://x-access-token:[secure]@github.com/rollercoaster-dev/openbadges-modular-server.git HEAD:main
+```
+
+**Key Findings**:
+1. **Semantic-release success**: Version 1.0.0 was successfully determined and package.json updated
+2. **Git plugin failure**: The `@semantic-release/git` plugin failed during the "prepare" step
+3. **Authentication bypass**: Plugin used its own git push command instead of respecting our GIT_ASKPASS setup
+4. **Exit code 1**: Git push failed with authentication/permission error
+
+**Error Timeline**:
+- `[4:33:34 PM]` - Semantic-release found 2 files to commit (package.json, CHANGELOG.md)
+- `[4:34:15 PM]` - Git plugin failed after ~40 seconds timeout
+- **Error**: `Command failed with exit code 1: git push --tags https://x-access-token:[secure]@github.com/rollercoaster-dev/openbadges-modular-server.git HEAD:main`
+
+### SOLUTION IMPLEMENTED: Git URL Rewriting for Semantic-Release
+**Task 5.1**: Configure semantic-release to use our GitHub App token properly ✅ COMPLETED
+- [x] **Implemented**: Git URL rewriting using `git config --global url.insteadOf`
+- [x] **Approach**: Configure git to automatically rewrite GitHub URLs to include authentication
+- [x] **Benefit**: Works with all git operations including semantic-release git plugin
+
+**Technical Implementation**:
+```bash
+git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+```
+
+**How it works**:
+- Any git operation using `https://github.com/` URLs automatically gets rewritten to include the token
+- Semantic-release git plugin will use the authenticated URL transparently
+- No changes needed to semantic-release configuration
+- Maintains security by using GitHub App token
+
+**Task 5.2**: Ensure git authentication consistency ✅ COMPLETED
+- [x] Git URL rewriting ensures all git operations use the same authentication
+- [x] Semantic-release will automatically use the GitHub App token
+- [x] No additional configuration needed in `.releaserc.json`
+
 ---
 
 **Notes:**
@@ -391,6 +435,6 @@ chmod +x $GIT_ASKPASS
 - **PHASE 2 COMPLETED**: Git plugin permissions addressed ✅
 - **PHASE 3 COMPLETED**: PAT_TOKEN authentication issues resolved ✅
 - **PHASE 4 COMPLETED**: GitHub App authentication implemented with security enhancements ✅
-- This systematic approach successfully resolved all CI/CD release issues
-- CodeRabbit suggestions validated and implemented for enhanced security
-- Ready for final testing and validation
+- **PHASE 5 IN PROGRESS**: Semantic-release git plugin authentication bypass identified ❌
+- **Critical Issue**: Semantic-release bypasses our GIT_ASKPASS configuration
+- **Next Focus**: Configure semantic-release to properly use GitHub App authentication

--- a/.augment/working/tasks/todo/ci-release-systematic-fix.md
+++ b/.augment/working/tasks/todo/ci-release-systematic-fix.md
@@ -428,6 +428,23 @@ git config --global url."https://x-access-token:${{ steps.app-token.outputs.toke
 - [x] Semantic-release will automatically use the GitHub App token
 - [x] No additional configuration needed in `.releaserc.json`
 
+**Task 5.3**: Create and test the fix ✅ COMPLETED
+- [x] Created feature branch: `fix/semantic-release-git-authentication`
+- [x] Implemented git URL rewriting solution
+- [x] All 751 tests pass with new implementation
+- [x] Created PR #79 for testing and review
+- [x] Ready for release workflow validation
+
+## PHASE 5 STATUS: ✅ COMPLETED - Solution Implemented
+
+### Summary
+Successfully identified and implemented a fix for the semantic-release git plugin authentication bypass issue. The solution uses git URL rewriting to ensure all git operations automatically use the GitHub App token, eliminating the authentication failures that were preventing releases.
+
+### Next Steps
+1. **Merge PR #79** to test the fix in the actual release workflow
+2. **Monitor release workflow** to validate the solution works end-to-end
+3. **Complete systematic fix** once release workflow succeeds
+
 ---
 
 **Notes:**
@@ -435,6 +452,6 @@ git config --global url."https://x-access-token:${{ steps.app-token.outputs.toke
 - **PHASE 2 COMPLETED**: Git plugin permissions addressed ✅
 - **PHASE 3 COMPLETED**: PAT_TOKEN authentication issues resolved ✅
 - **PHASE 4 COMPLETED**: GitHub App authentication implemented with security enhancements ✅
-- **PHASE 5 IN PROGRESS**: Semantic-release git plugin authentication bypass identified ❌
-- **Critical Issue**: Semantic-release bypasses our GIT_ASKPASS configuration
-- **Next Focus**: Configure semantic-release to properly use GitHub App authentication
+- **PHASE 5 COMPLETED**: Semantic-release git plugin authentication fix implemented ✅
+- **Solution Ready**: PR #79 created and ready for testing
+- **All Tests Passing**: 751 tests pass with the new implementation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -332,6 +332,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Mask GitHub App token
+        run: echo "::add-mask::${{ steps.app-token.outputs.token }}"
+
       - name: Configure Git
         run: |
           git config --global user.name "github-actions[bot]"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,12 +336,9 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Use GitHub App token for git push - bypasses branch protection for release commits
-          # Keep the remote URL token-free to avoid accidental leakage in debug output
-          git remote set-url origin https://github.com/${{ github.repository }}.git
-          export GIT_ASKPASS=$(mktemp)
-          echo "echo '${{ steps.app-token.outputs.token }}'" > $GIT_ASKPASS
-          chmod +x $GIT_ASKPASS
+          # Configure git to use GitHub App token for authentication
+          # This ensures semantic-release git plugin uses the correct token
+          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 
       - name: Release
         id: semantic


### PR DESCRIPTION
## Problem

The semantic-release git plugin was bypassing our GitHub App authentication setup, causing release failures with git push authentication errors.

**Root Cause**: The  plugin uses its own git push command and was not respecting our GIT_ASKPASS configuration.

## Solution

Implemented git URL rewriting using  to ensure all git operations (including semantic-release) automatically use the GitHub App token for authentication.

**Technical Details**:
- Replaced GIT_ASKPASS approach with git URL rewriting
- Any git operation using  URLs automatically gets rewritten to include the token
- Semantic-release git plugin will use the authenticated URL transparently
- No changes needed to semantic-release configuration
- Maintains security by using GitHub App token

## Changes

- Updated  to use git URL rewriting instead of GIT_ASKPASS
- Updated task documentation to reflect the implemented solution

## Testing

- ✅ All 751 tests pass
- ✅ Pre-push hooks pass (linting, type checking)
- ✅ Ready for release workflow testing

Addresses the semantic-release git plugin authentication bypass issue identified in release failure analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD release process by updating authentication for git operations to use global URL rewriting with the GitHub App token, ensuring consistent and secure authentication for all release steps.
  * Simplified workflow configuration by removing the use of temporary authentication scripts and explicit remote URL resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->