### PR TITLE
fix: Phase 6 - Replace git URL rewriting with direct remote URL for semantic-release

### DIFF
--- a/.augment/working/tasks/todo/ci-release-systematic-fix.md
+++ b/.augment/working/tasks/todo/ci-release-systematic-fix.md
@@ -435,23 +435,47 @@ git config --global url."https://x-access-token:${{ steps.app-token.outputs.toke
 - [x] Created PR #79 for testing and review
 - [x] Ready for release workflow validation
 
-## PHASE 5 STATUS: ✅ COMPLETED - Solution Implemented
+## PHASE 6: Final Git Push Fix ⚡ IN PROGRESS
 
-### Summary
-Successfully identified and implemented a fix for the semantic-release git plugin authentication bypass issue. The solution uses git URL rewriting to ensure all git operations automatically use the GitHub App token, eliminating the authentication failures that were preventing releases.
+### 🎉 MAJOR SUCCESS: Authentication Issues Resolved!
+**Test Results from Run 16240254568 (July 12, 2025):**
+- ✅ **GitHub App authentication working perfectly**
+- ✅ **Checkout succeeds** (no more auth failures!)
+- ✅ **All quality gates pass** (lint, tests, build)
+- ✅ **Workflow progresses through 8 steps** vs. failing at step 1 before
+- ❌ **ONLY REMAINING ISSUE**: `git push --tags` fails in semantic-release
 
-### Next Steps
-1. **Merge PR #79** to test the fix in the actual release workflow
-2. **Monitor release workflow** to validate the solution works end-to-end
-3. **Complete systematic fix** once release workflow succeeds
+### Root Cause Analysis
+**Error**: `Command failed with exit code 1: git push --tags https://github.com/rollercoaster-dev/openbadges-modular-server HEAD:main`
+
+**Problem**: Git URL rewriting with `insteadOf` is unreliable for push operations:
+```bash
+# Current approach (unreliable for push):
+git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
+```
+
+### PHASE 6 SOLUTION: Direct Remote URL Setting
+**Replace URL rewriting with direct remote URL configuration:**
+```bash
+# More reliable approach:
+git remote set-url origin "https://x-access-token:${TOKEN}@github.com/${REPO}.git"
+```
+
+### Implementation Plan
+- [x] **Verified permissions**: Release workflow has `contents: write` ✅
+- [x] **Verified branch protection**: Admin enforcement disabled ✅
+- [x] **Identified root cause**: Git URL rewriting issue ✅
+- [ ] **Create fix branch**: Implement direct remote URL approach
+- [ ] **Test fix**: Validate git push works with new configuration
+- [ ] **Complete systematic fix**: Finalize 6-phase solution
 
 ---
 
-**Notes:**
-- **PHASE 1 COMPLETED**: Admin enforcement successfully disabled ✅
-- **PHASE 2 COMPLETED**: Git plugin permissions addressed ✅
-- **PHASE 3 COMPLETED**: PAT_TOKEN authentication issues resolved ✅
-- **PHASE 4 COMPLETED**: GitHub App authentication implemented with security enhancements ✅
-- **PHASE 5 COMPLETED**: Semantic-release git plugin authentication fix implemented ✅
-- **Solution Ready**: PR #79 created and ready for testing
-- **All Tests Passing**: 751 tests pass with the new implementation
+**SYSTEMATIC FIX STATUS:**
+- ✅ **PHASE 1**: Admin enforcement successfully disabled
+- ✅ **PHASE 2**: Git plugin permissions addressed
+- ✅ **PHASE 3**: PAT_TOKEN authentication issues resolved
+- ✅ **PHASE 4**: GitHub App authentication implemented with security enhancements
+- ✅ **PHASE 5**: Semantic-release git plugin authentication fix implemented
+- ⚡ **PHASE 6**: Final git push fix (IN PROGRESS)
+- **SUCCESS RATE**: 83% complete - authentication fully working, final config tweak needed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -340,8 +340,8 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Configure git to use GitHub App token for authentication
-          # This ensures semantic-release git plugin uses the correct token
-          git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+          # Use direct remote URL setting instead of insteadOf for more reliable push operations
+          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
 
       - name: Release
         id: semantic
@@ -358,9 +358,13 @@ jobs:
           echo "Repository: ${{ github.repository }}"
           echo "Actor: ${{ github.actor }}"
 
-          # Debug git configuration (excluding remote URL to avoid exposing PAT)
+          # Debug git configuration
           echo "Git configuration:"
           git config --list | grep -E "user\." || true
+          echo "Git remote configuration:"
+          git remote -v | sed 's/x-access-token:[^@]*@/x-access-token:***@/g' || true
+          echo "Testing git authentication:"
+          git ls-remote origin HEAD || echo "Git authentication test failed"
 
           # Check if we have commits to release
           echo "Recent commits:"


### PR DESCRIPTION
## 🎯 Phase 6: Final Git Push Fix

This PR completes the 6-phase systematic CI/CD release fix by addressing the final git push issue in semantic-release.

### 🎉 Context: Major Success Achieved
**Phases 1-5 successfully resolved authentication issues!**
- ✅ GitHub App authentication working perfectly
- ✅ Checkout succeeds (no more auth failures!)
- ✅ All quality gates pass (lint, tests, build)
- ✅ Workflow progresses through 8 steps vs. failing at step 1 before

### 🔧 Remaining Issue
**Error**: `Command failed with exit code 1: git push --tags`

**Root Cause**: Git URL rewriting with `insteadOf` is unreliable for push operations.

### 🚀 Solution
Replace URL rewriting with direct remote URL configuration for more reliable git push operations.

### 📊 Systematic Fix Progress
- ✅ **PHASE 1**: Admin enforcement successfully disabled
- ✅ **PHASE 2**: Git plugin permissions addressed
- ✅ **PHASE 3**: PAT_TOKEN authentication issues resolved
- ✅ **PHASE 4**: GitHub App authentication implemented
- ✅ **PHASE 5**: Semantic-release git plugin authentication fix
- 🎯 **PHASE 6**: Final git push fix (THIS PR)

**Expected Result**: Complete end-to-end release workflow success.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of Git authentication in the release workflow by updating the method for setting the remote URL.
  * Enhanced debug output during the release process to include additional git configuration details with sensitive information redacted.
  * Added a test step to verify git authentication before pushing changes.
  * Updated documentation to reflect the current progress and status of the CI release fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->