### PR TITLE
fix: remove unnecessary pushArgs from semantic-release git configuration

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -16,8 +16,7 @@
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
-        "pushArgs": ["--no-verify"]
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
This PR removes the unnecessary `pushArgs` configuration from the semantic-release git plugin.

The `pushArgs` option was causing issues and is not needed since semantic-release handles the push operation correctly by default.

## Changes
- Removed `pushArgs` from `.releaserc.json` git plugin configuration

## Context
This commit was accidentally pushed directly to main and has been moved to this feature branch for proper review.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author